### PR TITLE
Add dependecy on suturo_msgs for travis.

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: suturo_msgs
+    uri: https://github.com/suturo16/suturo_msgs.git


### PR DESCRIPTION
Irgendwann werden die suturo_msgs zum Bauen benötigt werden. Daher sind sie jetzt auch in den dependencies die Travis sich zieht.